### PR TITLE
Issue 263 show homepage on browser nav back

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "1.0.2": "^1.0.0",
     "@fortawesome/pro-solid-svg-icons": "^5.8.2",
     "@philly/vue-comps": "^2.0.4",
-    "@philly/vue-datafetch": "^1.0.0",
+    "@philly/vue-datafetch": "https://github.com/CityOfPhiladelphia/phila-vue-datafetch#4f7524248a06a921131db48fba3a285355ba2026",
     "@philly/vue-mapping": "^2.0.2",
     "accounting": "^0.4.1",
     "core-js": "^3.4.7",

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -321,6 +321,10 @@ export default {
     },
   },
   watch: {
+    '$route': function(route) {
+      // return route.fullPath === '/' ? this.$store.commit('setIntroPage', true) : "";
+      return route.fullPath === '/' ? this.openIntroPage(true) : this.openIntroPage(false);
+    },
     activeModal() {
       this.$controller.activeFeatureChange();
     },
@@ -403,6 +407,12 @@ export default {
     window.removeEventListener('resize', this.onResize);
   },
   methods: {
+    openIntroPage(value){
+      this.$data.introPage = value
+      this.$store.commit('setFullScreenMapEnabled', value);
+      value = true ? this.$store.commit('setCyclomediaActive', false ): "";
+      return this.$store.commit('setIntroPage', value)
+    },
     onDataChange(type) {
       // console.log('onDataChange, type:', type)
       this.$data.hasData = true;


### PR DESCRIPTION
When using the browser to navigate back to the initial screen, feedback identified that the intro page and initial layout should be shown instead of just a blank table. Closes #263