### PR TITLE
Fix/restore zoning

### DIFF
--- a/src/components/DataPanel.vue
+++ b/src/components/DataPanel.vue
@@ -993,31 +993,31 @@ export default {
                 point.replace(/"/g, '""').trim()
           },
         },
-        // {
-        //   label: 'Zoning Code',
-        //   value: function(state, item){
-        //     let id = [];
-        //     state.geocode.status === "success"?  id =  item.properties.opa_account_num :
-        //       state.ownerSearch.status === "success" ? id =  item.properties.opa_account_num :
-        //         id = item.parcel_number;
-        //     if (typeof state.sources.opa_public.targets[id] != 'undefined' && id != "") {
-        //       return state.sources.opa_public.targets[id].data.zoning.trim();
-        //     } return "";
-        //   },
-        // },
-        // {
-        //   label: 'Zoning Description',
-        //   value: function (state, item) {
-        //     let id = [];
-        //     state.geocode.status === "success"?  id =  item.properties.opa_account_num :
-        //       state.ownerSearch.status === "success" ? id =  item.properties.opa_account_num :
-        //         id = item.parcel_number;
-        //     if (typeof state.sources.opa_public.targets[id] != 'undefined' && id != "") {
-        //       const code = state.sources.opa_public.targets[id].data.zoning ;
-        //       return helpers.ZONING_CODE_MAP[code.trim()];
-        //     }  return "";
-        //   },
-        // },
+        {
+          label: 'Zoning Code',
+          value: function(state, item){
+            let id = [];
+            state.geocode.status === "success"?  id =  item.properties.opa_account_num :
+              state.ownerSearch.status === "success" ? id =  item.properties.opa_account_num :
+                id = item.parcel_number;
+            if (typeof state.sources.opa_public.targets[id] != 'undefined' && id != "") {
+              return state.sources.opa_public.targets[id].data.zoning.trim();
+            } return "";
+          },
+        },
+        {
+          label: 'Zoning Description',
+          value: function (state, item) {
+            let id = [];
+            state.geocode.status === "success"?  id =  item.properties.opa_account_num :
+              state.ownerSearch.status === "success" ? id =  item.properties.opa_account_num :
+                id = item.parcel_number;
+            if (typeof state.sources.opa_public.targets[id] != 'undefined' && id != "") {
+              const code = state.sources.opa_public.targets[id].data.zoning ;
+              return helpers.ZONING_CODE_MAP[code.trim()];
+            }  return "";
+          },
+        },
       ];
     },
     mailingFields(state, item, thisDef) {

--- a/src/components/PropertyCardModal.vue
+++ b/src/components/PropertyCardModal.vue
@@ -523,16 +523,16 @@ export default {
             label: 'Beginning Point',
             value: opaPublicData.beginning_point,
           },
-          // {
-          //   label: 'Zoning',
-          //   value: function(state) {
-          //     return '<a target="_blank" \
-          //               href="https://atlas.phila.gov/#/'+ this.activeAddress + '/zoning ">\
-          //              <b>' + opaPublicData.zoning + '-' + helpers.ZONING_CODE_MAP[opaPublicData.zoning.trim()] + '</b>\
-          //              </b> <i class="fa fa-external-link-alt"></i></a>\
-          //              </a>';
-          //   }.bind(this),
-          // },
+          {
+            label: 'Zoning',
+            value: function(state) {
+              return '<a target="_blank" \
+                        href="https://atlas.phila.gov/#/'+ this.activeAddress + '/zoning ">\
+                       <b>' + opaPublicData.zoning + '-' + helpers.ZONING_CODE_MAP[opaPublicData.zoning.trim()] + '</b>\
+                       </b> <i class="fa fa-external-link-alt"></i></a>\
+                       </a>';
+            }.bind(this),
+          },
           {
             label: 'OPA Account Number',
             value: this.activeOpaId,

--- a/src/data-sources/opa-public.js
+++ b/src/data-sources/opa-public.js
@@ -53,7 +53,7 @@ export default {
     params: {
       q: function(input){
         // console.log('opa-public.js, input:', input);
-        return "select * from opa_properties_public where parcel_number IN("+ input +")";
+        return "select * from opa_properties_public_test where parcel_number IN("+ input +")";
       },
       // var inputEncoded = Object.keys(input).map(k => "'" + input[k] + "'").join(",");
     },


### PR DESCRIPTION
Changed data source and all of the fields should be the same so there shouldn't be any problems with field mapping using the new source. Per request from Alex, changed the data source from opa_properties_public to opa_properties_test. The test table is maintained and updated more regularly and otherwise there should be no changes between field names. (He will be updating the name from test to something permanent at some point soon, but this will require some time and effort.)

The zoning issue above should also be resolved thanks to an update on the back end to use the correct zoning source for this field.


![image](https://user-images.githubusercontent.com/10437857/75274938-af5b5080-57d1-11ea-94de-bb89da5cf4ae.png)

