### PR TITLE
Hot fix/datafetch commit clear sources on shape search

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "1.0.2": "^1.0.0",
     "@fortawesome/pro-solid-svg-icons": "^5.8.2",
     "@philly/vue-comps": "2.0.7",
-    "@philly/vue-datafetch": "https://github.com/CityOfPhiladelphia/phila-vue-datafetch#56e667c7924f8dd1f2094c097185c99dd21672db",
+    "@philly/vue-datafetch": "https://github.com/CityOfPhiladelphia/phila-vue-datafetch#baee69704412ff480fc8fca475b579ff85bdb1a9",
     "@philly/vue-mapping": "^2.0.2",
     "accounting": "^0.4.1",
     "core-js": "^3.4.7",

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -360,7 +360,7 @@ export default {
       }
     },
     ownerSearchTotal(newValue) {
-      if( newValue > this.$store.state.ownerSearch.data.length ){
+      if( this.$store.state.ownerSearch.data !== null && newValue > this.$store.state.ownerSearch.data.length ){
         this.$store.commit('setOwnerSearchModal', true);
       }
     },


### PR DESCRIPTION
fixes 2 errors currently crashing site. First is that shape searches are not clearing and fetching data sources for subsequent searches. Second is that a shape search after an owner search was creating another error. 