### PR TITLE
Fix/mobile css

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -428,6 +428,9 @@ export default {
       this.$store.commit('setLastSearchMethod', 'buffer search');
     }
   },
+  beforeMount(){
+    return this.$store.state.isMobileOrTablet ? this.$store.commit('setIntroPage', false) : "";
+  },
   created() {
     window.addEventListener('resize', this.onResize);
   },
@@ -711,6 +714,15 @@ export default {
 
 
 @media screen and (max-width: 750px) {
+
+  #map-panel-container {
+    height: 300px;
+  }
+
+
+  .main-content{
+    position: inherit;
+  }
 
   .pl-alert {
     height: 100% !important;

--- a/src/components/IntroPage.vue
+++ b/src/components/IntroPage.vue
@@ -9,7 +9,7 @@
       screen-percent="2"
       />
     <div
-      v-if="this.$store.state.activeModal.featureId === null"
+      v-if="this.$store.state.activeModal.featureId === null && !this.$store.state.isMobileOrTablet"
       class="introduction"
     >
       <div class="intro-blue">

--- a/src/components/PropertyCardModal.vue
+++ b/src/components/PropertyCardModal.vue
@@ -818,6 +818,10 @@ export default {
 
 @media screen and (min-width: 750px) {
 
+  /* .openmaps-modal-content{
+    height: 85%;
+  } */
+
   tr > td.big_owner {
     font-size: 32px;
     font-weight: 100;
@@ -1071,6 +1075,9 @@ export default {
     left: 0 !important;
     right: 0 !important;
   }
+  .openmaps-modal-content {
+    height: auto !important;
+  }
 }
 
 @media screen {
@@ -1168,7 +1175,6 @@ header {
 }
 
 .openmaps-modal-content{
-  height: 85%;
   padding: 0 20px;
 }
 


### PR DESCRIPTION
The CSS currently causes the map not to display in mobile. I added a fixed width of 300px to get he map to display and hid the intro page on mobile. The downside is that on page open the map isn't full screen, but I wasn't able to get a height of 100% to work.

 Another note, the address header in the property card is not fixed in mobile bc the app header isn't fixed either.