### PR TITLE
Sort API results by address

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,3 +143,5 @@ fix: css changes to avoid using postition absolute bc it causes issues rendering
 ### 3-8-2022
 + merges condo error handling into prod - failed address shows in url, error message does not flash between searches, fixes buffer search
 + upgrade node version
+### 5-4-2022
++ Add slight change to the AIS and carto calls to sort the results by address to help when displaying a large number of results or when adding condo units to existing results. 

--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -175,7 +175,7 @@ export default {
 }
 
 .red {
-  color: red;
+  color: #cc3000;
   padding-top: 5px;
 }
 


### PR DESCRIPTION
Sorting the results by address helps display them in the panel sorted which is extremely helpful when you get a large number of results from a shape search or when using the button to added condo units to the results